### PR TITLE
feat(id3tag): refactor file handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ venv/
 ENV/
 .spyderproject
 .ropeproject
+.vscode


### PR DESCRIPTION
Changes:
* fix support for files that have no `track` info in playlist (basically that affects files uploaded to GM).
* fix id3tag handling on windows for filenames containing non-English characters (it's workaround of eyed3 bug https://github.com/nicfit/eyeD3/issues/146). That's why tmp file is needed. If eyed3 will be fixed, `create_tmp_file` could be removed.
* add more id3tags and album art to resulting file.

PS: I'm not a python dev, so feel free to change the code if you don't like it. Tested this code for my own collection - all seems work fine (actually now it works and not crashes because of lack of `track` attr)